### PR TITLE
Replace use of ResourceLoader::makeMessageSetScript()

### DIFF
--- a/includes/Console/ConsoleView.php
+++ b/includes/Console/ConsoleView.php
@@ -62,7 +62,7 @@ class ConsoleView {
 		// wrap it up for use in the browser
 		$output->addScript(
 			\ResourceLoader::makeInlineScript(
-				\ResourceLoader::makeMessageSetScript( [ 'pickle-console-question' => $question ] ),
+				\Xml::encodeJsCall( 'mw.messages.set', [ [ 'pickle-console-question' => $question ] ] ),
 				$output->getCSPNonce()
 			)
 		);


### PR DESCRIPTION
This method is no longer used internally by ResourceLoader, and will be removed in a future release.

Messages for JavaScript should be bundled with the JavaScript code that uses those messages.

See [ResourceModules](https://www.mediawiki.org/wiki/Manual:$wgResourceModules) manual and [documentation entry](https://doc.wikimedia.org/mediawiki-core/master/php/DefaultSettings_8php.html#a5d4d23d2875c6176125328fdde44010e).